### PR TITLE
Add xslt and raise memory limit in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,7 @@ RUN apt update && \
         libldap2-dev \
         libldb-dev \
         libpng-dev \
+        libxslt1-dev \
         mysql-client \
         unzip \
         wget \
@@ -26,6 +27,7 @@ RUN apt update && \
     rm composer-setup.php && \
     mv /var/www/html/composer.phar /usr/bin/composer && \
     docker-php-ext-install \
+        xsl \
         gd \
         intl \
         ldap \
@@ -34,7 +36,8 @@ RUN apt update && \
     apt remove -y wget && \
     apt -y autoremove && \
     apt clean && \
-    cp /usr/local/etc/php/php.ini-production /usr/local/etc/php/php.ini
+    cp /usr/local/etc/php/php.ini-production /usr/local/etc/php/php.ini && \
+    echo 'memory_limit = 512M' >> /usr/local/etc/php/conf.d/docker-php-memlimit.ini;
 
 FROM tmp_kimai2_base
 


### PR DESCRIPTION
## Description
This patch fixes `docker build` which failed due to missing `xslt` and php memory limit constraint.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [x] I verified that my code applies to the guidelines (`composer code-check`)
    **Patch only affects docker**
- [x] I updated the documentation (see [here](https://github.com/kimai/www.kimai.org/tree/master/_documentation))
    **No documentation change required, really**
- [x] I agree that this code is used in Kimai and will be published under the [MIT license](https://github.com/kevinpapst/kimai2/blob/master/LICENSE)
